### PR TITLE
Add point cloud edge classification example

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -1,0 +1,43 @@
+from typing import List, Tuple
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+from torch_geometric.data import Data
+from torch_geometric.nn import knn_graph
+
+
+def read_data_list(list_file: str) -> List[Tuple[str, str]]:
+    """Read a text file with lines of `point_path label_path`."""
+    pairs = []
+    with open(list_file, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            point_path, label_path = line.split()
+            pairs.append((point_path, label_path))
+    return pairs
+
+
+class PointCloudEdgeDataset(Dataset):
+    """Dataset for edge classification in point clouds."""
+
+    def __init__(self, samples: List[Tuple[str, str]], k: int = 20):
+        self.samples = samples
+        self.k = k
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+    def __getitem__(self, idx: int) -> Data:
+        point_path, label_path = self.samples[idx]
+        pts = np.load(point_path)  # (N,6)
+        labels = np.load(label_path)  # (N,1) or (N,)
+
+        pts = torch.from_numpy(pts).float()
+        labels = torch.from_numpy(labels).view(-1).float()
+
+        edge_index = knn_graph(pts[:, :3], k=self.k, loop=False)
+        data = Data(x=pts, edge_index=edge_index, y=labels)
+        return data

--- a/model.py
+++ b/model.py
@@ -1,0 +1,33 @@
+from torch import nn
+import torch.nn.functional as F
+from torch_geometric.nn import GraphConv, BatchNorm
+
+
+class GBCNN(nn.Module):
+    """Simple graph-based CNN for point-wise edge classification."""
+
+    def __init__(self, input_dim: int = 6):
+        super().__init__()
+        self.conv1 = GraphConv(input_dim, 64)
+        self.bn1 = BatchNorm(64)
+        self.conv2 = GraphConv(64, 128)
+        self.bn2 = BatchNorm(128)
+        self.conv3 = GraphConv(128, 256)
+        self.bn3 = BatchNorm(256)
+
+        self.head = nn.Sequential(
+            nn.Linear(256, 128),
+            nn.ReLU(),
+            nn.Linear(128, 1)
+        )
+
+    def forward(self, data):
+        x, edge_index = data.x, data.edge_index
+        x = self.conv1(x, edge_index)
+        x = F.relu(self.bn1(x))
+        x = self.conv2(x, edge_index)
+        x = F.relu(self.bn2(x))
+        x = self.conv3(x, edge_index)
+        x = F.relu(self.bn3(x))
+        x = self.head(x).squeeze(-1)
+        return x

--- a/train.py
+++ b/train.py
@@ -1,0 +1,88 @@
+import argparse
+import torch
+from torch import nn
+from torch.optim import Adam
+from torch.cuda.amp import autocast, GradScaler
+from torch_geometric.loader import DataLoader
+
+from dataset import PointCloudEdgeDataset, read_data_list
+from model import GBCNN
+from utils import compute_metrics
+
+
+def build_dataloader(list_file: str, batch_size: int, shuffle: bool) -> DataLoader:
+    samples = read_data_list(list_file)
+    dataset = PointCloudEdgeDataset(samples, k=20)
+    return DataLoader(dataset, batch_size=batch_size, shuffle=shuffle)
+
+
+def train_epoch(model, loader, criterion, optimizer, scaler, device, use_amp):
+    model.train()
+    total_loss = 0.0
+    for data in loader:
+        data = data.to(device)
+        optimizer.zero_grad()
+        with autocast(enabled=use_amp):
+            logits = model(data)
+            loss = criterion(logits, data.y)
+        scaler.scale(loss).backward()
+        scaler.step(optimizer)
+        scaler.update()
+        total_loss += loss.item() * data.num_graphs
+    return total_loss / len(loader.dataset)
+
+
+def evaluate(model, loader, criterion, device, use_amp):
+    model.eval()
+    total_loss = 0.0
+    all_preds = []
+    all_labels = []
+    with torch.no_grad():
+        for data in loader:
+            data = data.to(device)
+            with autocast(enabled=use_amp):
+                logits = model(data)
+                loss = criterion(logits, data.y)
+            preds = torch.sigmoid(logits)
+            all_preds.append(preds.cpu())
+            all_labels.append(data.y.cpu())
+            total_loss += loss.item() * data.num_graphs
+    all_preds = torch.cat(all_preds).numpy()
+    all_labels = torch.cat(all_labels).numpy()
+    metrics = compute_metrics(all_labels, all_preds)
+    avg_loss = total_loss / len(loader.dataset)
+    return avg_loss, metrics
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Edge classification training")
+    parser.add_argument("--train-list", required=True)
+    parser.add_argument("--val-list", required=True)
+    parser.add_argument("--epochs", type=int, default=10)
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--amp", action="store_true", help="Use mixed precision")
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    train_loader = build_dataloader(args.train_list, args.batch_size, shuffle=True)
+    val_loader = build_dataloader(args.val_list, args.batch_size, shuffle=False)
+
+    model = GBCNN(input_dim=6).to(device)
+    optimizer = Adam(model.parameters(), lr=args.lr)
+    criterion = nn.BCEWithLogitsLoss(pos_weight=torch.tensor([10.0], device=device))
+    scaler = GradScaler(enabled=args.amp)
+
+    for epoch in range(1, args.epochs + 1):
+        train_loss = train_epoch(model, train_loader, criterion, optimizer, scaler, device, args.amp)
+        val_loss, metrics = evaluate(model, val_loader, criterion, device, args.amp)
+        print(
+            f"Epoch {epoch}: train_loss={train_loss:.4f} val_loss={val_loss:.4f} "
+            f"acc={metrics['accuracy']:.4f} prec={metrics['precision']:.4f} "
+            f"rec={metrics['recall']:.4f} f1={metrics['f1']:.4f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,15 @@
+from typing import Dict
+import numpy as np
+from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score
+
+
+def compute_metrics(y_true: np.ndarray, y_pred: np.ndarray) -> Dict[str, float]:
+    """Compute evaluation metrics using sklearn."""
+    pred_bin = (y_pred > 0.5).astype(np.int32)
+    metrics = {
+        'accuracy': accuracy_score(y_true, pred_bin),
+        'precision': precision_score(y_true, pred_bin, zero_division=0),
+        'recall': recall_score(y_true, pred_bin, zero_division=0),
+        'f1': f1_score(y_true, pred_bin, zero_division=0),
+    }
+    return metrics


### PR DESCRIPTION
## Summary
- add dataset loader for edge classification
- add GBCNN model using GraphConv layers
- add utilities for metrics
- add training loop with evaluation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68461b8c74c4832492b3f142b9c604c1