### PR TITLE
Handle single-file dataset format

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,18 @@ The training and validation data are provided as `.npy` files:
 
 - **Point clouds**: arrays of shape `(N, 6)` containing `[x, y, z, nx, ny, nz]`.
 - **Labels**: arrays of shape `(N, 1)` with `0` for non-edge and `1` for edge.
+  Alternatively a single file may store seven columns
+  `[x, y, z, nx, ny, nz, label]`. When the same path is specified for both the
+  point cloud and label entry, the dataset loader splits the file into the first
+  six columns as the point cloud and the last column as labels.
 
 You can store the data anywhere on your system. Create text files listing the paths to the point and label pairs:
 
 ```text
 /path/to/cloud1.npy /path/to/labels1.npy
 /path/to/cloud2.npy /path/to/labels2.npy
+# or, when a single file contains both point cloud and labels
+/path/to/cloud3.npy /path/to/cloud3.npy
 ...
 ```
 


### PR DESCRIPTION
## Summary
- allow PointCloudEdgeDataset to split 7-column .npy files when point path and label path are identical
- document single-file usage in README

## Testing
- `python -m py_compile dataset.py`
- `python -m py_compile train.py model.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_684706f03a1483248ef226e788c1360a